### PR TITLE
Update vaccine-medicinal-product.json

### DIFF
--- a/valuesets/vaccine-medicinal-product.json
+++ b/valuesets/vaccine-medicinal-product.json
@@ -4,6 +4,7 @@
   "valueSetValues": {
     "EU/1/20/1528": {
       "display": "Comirnaty",
+      "manf-code" : "ORG-100030215",
       "lang": "en",
       "active": true,
       "system": "https://ec.europa.eu/health/documents/community-register/html/",
@@ -11,6 +12,7 @@
     },
     "EU/1/20/1507": {
       "display": "COVID-19 Vaccine Moderna",
+      "manf-code" : "ORG-100031184",
       "lang": "en",
       "active": true,
       "system": "https://ec.europa.eu/health/documents/community-register/html/",
@@ -18,6 +20,7 @@
     },
     "EU/1/21/1529": {
       "display": "Vaxzevria",
+      "manf-code" : "ORG-100001699",
       "lang": "en",
       "active": true,
       "system": "https://ec.europa.eu/health/documents/community-register/html/",
@@ -25,6 +28,7 @@
     },
     "EU/1/20/1525": {
       "display": "COVID-19 Vaccine Janssen",
+      "manf-code" : "ORG-100001417",
       "lang": "en",
       "active": true,
       "system": "https://ec.europa.eu/health/documents/community-register/html/",
@@ -32,6 +36,7 @@
     },
     "CVnCoV": {
       "display": "CVnCoV",
+      "manf-code" : "ORG-100006270",
       "lang": "en",
       "active": true,
       "system": "http://ec.europa.eu/temp/vaccineproductname",
@@ -39,6 +44,7 @@
     },
     "Sputnik-V": {
       "display": "Sputnik-V",
+      "manf-code" : "Gamaleya-Research-Institute",
       "lang": "en",
       "active": true,
       "system": "http://ec.europa.eu/temp/vaccineproductname",
@@ -46,6 +52,7 @@
     },
     "Convidecia": {
       "display": "Convidecia",
+      "manf-code" : "ORG-100013793",
       "lang": "en",
       "active": true,
       "system": "http://ec.europa.eu/temp/vaccineproductname",
@@ -53,6 +60,7 @@
     },
     "EpiVacCorona": {
       "display": "EpiVacCorona",
+      "manf-code" : "Vector-Institute",
       "lang": "en",
       "active": true,
       "system": "http://ec.europa.eu/temp/vaccineproductname",
@@ -60,6 +68,7 @@
     },
     "BBIBP-CorV": {
       "display": "BBIBP-CorV",
+      "manf-code" : "ORG-100020693",
       "lang": "en",
       "active": true,
       "system": "http://ec.europa.eu/temp/vaccineproductname",
@@ -67,6 +76,7 @@
     },
     "Inactivated-SARS-CoV-2-Vero-Cell": {
       "display": "Inactivated SARS-CoV-2 (Vero Cell)",
+      "manf-code" : "Sinovac-Biotech",
       "lang": "en",
       "active": true,
       "system": "http://ec.europa.eu/temp/vaccineproductname",
@@ -74,6 +84,7 @@
     },
     "CoronaVac": {
       "display": "CoronaVac",
+      "manf-code" : "Sinovac-Biotech",
       "lang": "en",
       "active": true,
       "system": "http://ec.europa.eu/temp/vaccineproductname",
@@ -81,6 +92,7 @@
     },
     "Covaxin": {
       "display": "Covaxin (also known as BBV152 A, B, C)",
+      "manf-code" : "Bharat-Biotech",
       "lang": "en",
       "active": true,
       "system": "http://ec.europa.eu/temp/vaccineproductname",


### PR DESCRIPTION
To allow validation of the relation between product and product manufacturer in the vaccination certificate a new element "manf-code" has been added into the "vaccine-medication-product" value set. Each vaccine is identified using its EMA registration number or  - for vaccines that do not  have EMA registration yet and has be registered only by national authorities - a vaccine name. Each registration is linked to one marketing authorization holder or manufacturer entry from the "vaccine-mah-manf" value set but information about this relation is currently missing in the value sets distributed by DCCG and cannot be used for certificate validation. This change overcomes this problem. 